### PR TITLE
Use `exactRef` or `findRef` instead of the deprecated `getRef` method

### DIFF
--- a/src/main/java/org/dstadler/jgit/OpenRepository.java
+++ b/src/main/java/org/dstadler/jgit/OpenRepository.java
@@ -16,15 +16,15 @@ package org.dstadler.jgit;
    limitations under the License.
  */
 
-import java.io.File;
-import java.io.IOException;
-
 import org.dstadler.jgit.helper.CookbookHelper;
 import org.eclipse.jgit.api.Git;
 import org.eclipse.jgit.api.errors.GitAPIException;
 import org.eclipse.jgit.lib.Ref;
 import org.eclipse.jgit.lib.Repository;
 import org.eclipse.jgit.storage.file.FileRepositoryBuilder;
+
+import java.io.File;
+import java.io.IOException;
 
 
 
@@ -48,7 +48,7 @@ public class OpenRepository {
             System.out.println("Having repository: " + repository.getDirectory());
 
             // the Ref holds an ObjectId for any type of object (tree, commit, blob, tree)
-            Ref head = repository.getRef("refs/heads/master");
+            Ref head = repository.exactRef("refs/heads/master");
             System.out.println("Ref of refs/heads/master: " + head);
         }
     }

--- a/src/main/java/org/dstadler/jgit/api/GetRefFromName.java
+++ b/src/main/java/org/dstadler/jgit/api/GetRefFromName.java
@@ -16,12 +16,11 @@ package org.dstadler.jgit.api;
    limitations under the License.
  */
 
-import java.io.IOException;
-
 import org.dstadler.jgit.helper.CookbookHelper;
 import org.eclipse.jgit.lib.Ref;
 import org.eclipse.jgit.lib.Repository;
 
+import java.io.IOException;
 /**
  * Simple snippet which shows how to retrieve a Ref for some reference string.
  */
@@ -30,7 +29,7 @@ public class GetRefFromName {
     public static void main(String[] args) throws IOException {
         try (Repository repository = CookbookHelper.openJGitCookbookRepository()) {
             // the Ref holds an ObjectId for any type of object (tree, commit, blob, tree)
-            Ref head = repository.getRef("refs/heads/master");
+            Ref head = repository.exactRef("refs/heads/master");
             System.out.println("Ref of refs/heads/master: " + head + ": " + head.getName() + " - " + head.getObjectId().getName());
         }
     }

--- a/src/main/java/org/dstadler/jgit/api/GetRevCommitFromObjectId.java
+++ b/src/main/java/org/dstadler/jgit/api/GetRevCommitFromObjectId.java
@@ -16,14 +16,14 @@ package org.dstadler.jgit.api;
    limitations under the License.
  */
 
-import java.io.IOException;
-
 import org.dstadler.jgit.helper.CookbookHelper;
 import org.eclipse.jgit.lib.ObjectId;
 import org.eclipse.jgit.lib.Ref;
 import org.eclipse.jgit.lib.Repository;
 import org.eclipse.jgit.revwalk.RevCommit;
 import org.eclipse.jgit.revwalk.RevWalk;
+
+import java.io.IOException;
 
 /**
  * Simple snippet which shows how to use RevWalk to iterate over objects
@@ -32,7 +32,7 @@ public class GetRevCommitFromObjectId {
 
     public static void main(String[] args) throws IOException {
         try (Repository repository = CookbookHelper.openJGitCookbookRepository()) {
-            Ref head = repository.getRef("refs/heads/master");
+            Ref head = repository.exactRef("refs/heads/master");
             System.out.println("Found head: " + head);
 
             // a RevWalk allows to walk over commits based on some filtering that is defined

--- a/src/main/java/org/dstadler/jgit/api/GetRevTreeFromObjectId.java
+++ b/src/main/java/org/dstadler/jgit/api/GetRevTreeFromObjectId.java
@@ -16,14 +16,14 @@ package org.dstadler.jgit.api;
    limitations under the License.
  */
 
-import java.io.IOException;
-
 import org.dstadler.jgit.helper.CookbookHelper;
 import org.eclipse.jgit.lib.Ref;
 import org.eclipse.jgit.lib.Repository;
 import org.eclipse.jgit.revwalk.RevCommit;
 import org.eclipse.jgit.revwalk.RevTree;
 import org.eclipse.jgit.revwalk.RevWalk;
+
+import java.io.IOException;
 
 /**
  * Simple snippet which shows how to use RevWalk to iterate over objects
@@ -33,7 +33,7 @@ public class GetRevTreeFromObjectId {
     public static void main(String[] args) throws IOException {
         try (Repository repository = CookbookHelper.openJGitCookbookRepository()) {
             // See e.g. GetRevCommitFromObjectId for how to use a SHA-1 directly
-            Ref head = repository.getRef("HEAD");
+            Ref head = repository.findRef("HEAD");
             System.out.println("Ref of HEAD: " + head + ": " + head.getName() + " - " + head.getObjectId().getName());
 
             // a RevWalk allows to walk over commits based on some filtering that is defined

--- a/src/main/java/org/dstadler/jgit/api/ReadBlobContents.java
+++ b/src/main/java/org/dstadler/jgit/api/ReadBlobContents.java
@@ -16,8 +16,6 @@ package org.dstadler.jgit.api;
    limitations under the License.
  */
 
-import java.io.IOException;
-
 import org.dstadler.jgit.helper.CookbookHelper;
 import org.eclipse.jgit.lib.ObjectLoader;
 import org.eclipse.jgit.lib.Ref;
@@ -25,6 +23,8 @@ import org.eclipse.jgit.lib.Repository;
 import org.eclipse.jgit.revwalk.RevCommit;
 import org.eclipse.jgit.revwalk.RevTree;
 import org.eclipse.jgit.revwalk.RevWalk;
+
+import java.io.IOException;
 
 /**
  * Simple snippet which shows how to retrieve a Ref for some reference string.
@@ -34,7 +34,7 @@ public class ReadBlobContents {
     public static void main(String[] args) throws IOException {
         try (Repository repository = CookbookHelper.openJGitCookbookRepository()) {
             // the Ref holds an ObjectId for any type of object (tree, commit, blob, tree)
-            Ref head = repository.getRef("refs/heads/master");
+            Ref head = repository.exactRef("refs/heads/master");
             System.out.println("Ref of refs/heads/master: " + head);
 
             System.out.println("\nPrint contents of head of master branch, i.e. the latest commit information");

--- a/src/main/java/org/dstadler/jgit/api/ReadTagFromName.java
+++ b/src/main/java/org/dstadler/jgit/api/ReadTagFromName.java
@@ -16,14 +16,14 @@ package org.dstadler.jgit.api;
    limitations under the License.
  */
 
-import java.io.IOException;
-
 import org.dstadler.jgit.helper.CookbookHelper;
 import org.eclipse.jgit.lib.ObjectLoader;
 import org.eclipse.jgit.lib.Ref;
 import org.eclipse.jgit.lib.Repository;
 import org.eclipse.jgit.revwalk.RevObject;
 import org.eclipse.jgit.revwalk.RevWalk;
+
+import java.io.IOException;
 
 /**
  * Simple snippet which shows how to use RevWalk to read tags
@@ -35,12 +35,12 @@ public class ReadTagFromName {
             // a RevWalk allows to retrieve information from the repository
             try (RevWalk walk = new RevWalk(repository)) {
                 // a simple tag that is not annotated
-                Ref simpleTag = repository.getRef("initialtag");
+                Ref simpleTag = repository.findRef("initialtag");
                 RevObject any = walk.parseAny(simpleTag.getObjectId());
                 System.out.println("Commit: " + any);
 
                 // an annotated tag
-                Ref annotatedTag = repository.getRef("secondtag");
+                Ref annotatedTag = repository.findRef("secondtag");
                 any = walk.parseAny(annotatedTag.getObjectId());
                 System.out.println("Tag: " + any);
 

--- a/src/main/java/org/dstadler/jgit/api/WalkRev.java
+++ b/src/main/java/org/dstadler/jgit/api/WalkRev.java
@@ -16,13 +16,13 @@ package org.dstadler.jgit.api;
    limitations under the License.
  */
 
-import java.io.IOException;
-
 import org.dstadler.jgit.helper.CookbookHelper;
 import org.eclipse.jgit.lib.Ref;
 import org.eclipse.jgit.lib.Repository;
 import org.eclipse.jgit.revwalk.RevCommit;
 import org.eclipse.jgit.revwalk.RevWalk;
+
+import java.io.IOException;
 
 
 
@@ -33,7 +33,7 @@ public class WalkRev {
 
     public static void main(String[] args) throws IOException {
         try (Repository repository = CookbookHelper.openJGitCookbookRepository()) {
-            Ref head = repository.getRef("refs/heads/master");
+            Ref head = repository.exactRef("refs/heads/master");
 
             // a RevWalk allows to walk over commits based on some filtering that is defined
             try (RevWalk walk = new RevWalk(repository)) {

--- a/src/main/java/org/dstadler/jgit/porcelain/AddAndListNoteOfCommit.java
+++ b/src/main/java/org/dstadler/jgit/porcelain/AddAndListNoteOfCommit.java
@@ -16,9 +16,6 @@ package org.dstadler.jgit.porcelain;
    limitations under the License.
  */
 
-import java.io.IOException;
-import java.util.List;
-
 import org.dstadler.jgit.helper.CookbookHelper;
 import org.eclipse.jgit.api.Git;
 import org.eclipse.jgit.api.errors.GitAPIException;
@@ -28,6 +25,9 @@ import org.eclipse.jgit.lib.Repository;
 import org.eclipse.jgit.notes.Note;
 import org.eclipse.jgit.revwalk.RevCommit;
 import org.eclipse.jgit.revwalk.RevWalk;
+
+import java.io.IOException;
+import java.util.List;
 
 
 
@@ -40,7 +40,7 @@ public class AddAndListNoteOfCommit {
 
 	public static void main(String[] args) throws IOException, GitAPIException {
 		try (Repository repository = CookbookHelper.openJGitCookbookRepository()) {
-    		Ref head = repository.getRef("refs/heads/master");
+    		Ref head = repository.exactRef("refs/heads/master");
     		System.out.println("Found head: " + head);
 
             try (RevWalk walk = new RevWalk(repository)) {

--- a/src/main/java/org/dstadler/jgit/porcelain/ShowBranchDiff.java
+++ b/src/main/java/org/dstadler/jgit/porcelain/ShowBranchDiff.java
@@ -16,9 +16,6 @@ package org.dstadler.jgit.porcelain;
    limitations under the License.
  */
 
-import java.io.IOException;
-import java.util.List;
-
 import org.dstadler.jgit.helper.CookbookHelper;
 import org.eclipse.jgit.api.Git;
 import org.eclipse.jgit.api.errors.GitAPIException;
@@ -34,6 +31,9 @@ import org.eclipse.jgit.revwalk.RevWalk;
 import org.eclipse.jgit.treewalk.AbstractTreeIterator;
 import org.eclipse.jgit.treewalk.CanonicalTreeParser;
 
+import java.io.IOException;
+import java.util.List;
+
 
 
 /**
@@ -46,7 +46,7 @@ public class ShowBranchDiff {
     public static void main(String[] args) throws IOException, GitAPIException {
         try (Repository repository = CookbookHelper.openJGitCookbookRepository()) {
             try (Git git = new Git(repository)) {
-                if(repository.getRef("refs/heads/testbranch") == null) {
+                if(repository.exactRef("refs/heads/testbranch") == null) {
                     // first we need to ensure that the remote branch is visible locally
                     Ref ref = git.branchCreate().setName("testbranch").setStartPoint("origin/testbranch").call();
 
@@ -70,7 +70,7 @@ public class ShowBranchDiff {
             MissingObjectException,
             IncorrectObjectTypeException {
         // from the commit we can build the tree which allows us to construct the TreeParser
-        Ref head = repository.getRef(ref);
+        Ref head = repository.exactRef(ref);
         try (RevWalk walk = new RevWalk(repository)) {
             RevCommit commit = walk.parseCommit(head.getObjectId());
             RevTree tree = walk.parseTree(commit.getTree().getId());

--- a/src/main/java/org/dstadler/jgit/unfinished/WalkTreeNonRecursive.java
+++ b/src/main/java/org/dstadler/jgit/unfinished/WalkTreeNonRecursive.java
@@ -16,8 +16,6 @@ package org.dstadler.jgit.unfinished;
    limitations under the License.
  */
 
-import java.io.IOException;
-
 import org.dstadler.jgit.helper.CookbookHelper;
 import org.eclipse.jgit.lib.Ref;
 import org.eclipse.jgit.lib.Repository;
@@ -25,6 +23,8 @@ import org.eclipse.jgit.revwalk.RevCommit;
 import org.eclipse.jgit.revwalk.RevTree;
 import org.eclipse.jgit.revwalk.RevWalk;
 import org.eclipse.jgit.treewalk.TreeWalk;
+
+import java.io.IOException;
 
 /**
  * Note: This snippet is not done and likely does not show anything useful yet
@@ -37,7 +37,7 @@ public class WalkTreeNonRecursive {
 
     public static void main(String[] args) throws IOException {
         try (Repository repository = CookbookHelper.openJGitCookbookRepository()) {
-            Ref head = repository.getRef("HEAD");
+            Ref head = repository.findRef("HEAD");
 
             // a RevWalk allows to walk over commits based on some filtering that is defined
             try (RevWalk walk = new RevWalk(repository)) {

--- a/src/main/java/org/dstadler/jgit/unfinished/WalkTreeRecursive.java
+++ b/src/main/java/org/dstadler/jgit/unfinished/WalkTreeRecursive.java
@@ -16,8 +16,6 @@ package org.dstadler.jgit.unfinished;
    limitations under the License.
  */
 
-import java.io.IOException;
-
 import org.dstadler.jgit.helper.CookbookHelper;
 import org.eclipse.jgit.lib.Ref;
 import org.eclipse.jgit.lib.Repository;
@@ -25,6 +23,8 @@ import org.eclipse.jgit.revwalk.RevCommit;
 import org.eclipse.jgit.revwalk.RevTree;
 import org.eclipse.jgit.revwalk.RevWalk;
 import org.eclipse.jgit.treewalk.TreeWalk;
+
+import java.io.IOException;
 
 /**
  * Note: This snippet is not done and likely does not show anything useful yet
@@ -37,7 +37,7 @@ public class WalkTreeRecursive {
 
     public static void main(String[] args) throws IOException {
         try (Repository repository = CookbookHelper.openJGitCookbookRepository()) {
-            Ref head = repository.getRef("HEAD");
+            Ref head = repository.findRef("HEAD");
 
             // a RevWalk allows to walk over commits based on some filtering that is defined
             try (RevWalk walk = new RevWalk(repository)) {

--- a/src/test/java/org/dstadler/jgit/JGitBugTest.java
+++ b/src/test/java/org/dstadler/jgit/JGitBugTest.java
@@ -1,9 +1,5 @@
 package org.dstadler.jgit;
 
-import static org.junit.Assert.assertNotNull;
-
-import java.io.IOException;
-
 import org.dstadler.jgit.helper.CookbookHelper;
 import org.eclipse.jgit.lib.ObjectLoader;
 import org.eclipse.jgit.lib.ObjectReader;
@@ -11,6 +7,10 @@ import org.eclipse.jgit.lib.Ref;
 import org.eclipse.jgit.lib.Repository;
 import org.eclipse.jgit.revwalk.RevWalk;
 import org.junit.Test;
+
+import java.io.IOException;
+
+import static org.junit.Assert.assertNotNull;
 
 /**
  * Tests which show issues with JGit that we reported upstream.
@@ -23,7 +23,7 @@ public class JGitBugTest {
                 try (RevWalk walk = new RevWalk(reader)) {
                     walk.dispose();
 
-                    Ref head = repo.getRef("refs/heads/master");
+                    Ref head = repo.exactRef("refs/heads/master");
                     System.out.println("Found head: " + head);
 
                     ObjectLoader loader = reader.open(head.getObjectId());


### PR DESCRIPTION
Just FYI, if I add my own remote repo and name it "origin" and rename your remote repo to something else, "FetchRemoteCommits" test will fail with an Authentification error