### PR TITLE
fix copy/paste mistake in GetFileAttributes

### DIFF
--- a/src/main/java/org/dstadler/jgit/api/GetFileAttributes.java
+++ b/src/main/java/org/dstadler/jgit/api/GetFileAttributes.java
@@ -89,7 +89,7 @@ public class GetFileAttributes {
             treeWalk.setRecursive(false);
             treeWalk.setFilter(PathFilter.create("src"));
             if (!treeWalk.next()) {
-                throw new IllegalStateException("Did not find expected file 'README.md'");
+                throw new IllegalStateException("Did not find expected folder 'src'");
             }
 
             // FileMode now indicates that this is a directory, i.e. FileMode.TREE.equals(fileMode) holds true


### PR DESCRIPTION
Hey guys,

Thanks for this cookbook. Its amazing. I found a copy/paste mistake in printDirectory function in GetFileAttributes. This PR fixes it

Thanks
Mahesh