### PR TITLE
Add example of deleting files

### DIFF
--- a/src/main/java/org/dstadler/jgit/porcelain/CommitAll.java
+++ b/src/main/java/org/dstadler/jgit/porcelain/CommitAll.java
@@ -32,8 +32,11 @@ public class CommitAll {
                     throw new IOException("Could not create file " + myFile);
                 }
 
-                // Stage all files in the repo including new files
+                // Stage all files in the repo including new files, excluding deleted files
                 git.add().addFilepattern(".").call();
+
+                // Stage all changed files, including deleted files, excluding new files
+                git.add().addFilepattern(".").setUpdate(true).call();
 
                 // and then commit the changes.
                 git.commit()


### PR DESCRIPTION
JGit's `add()` behaves slightly different from `git add` command. If files were deleted in file system, skipping `JGit.rm()` call, they won't be staged by calling `git.add().addFilepatttern(".")`. The easiest way to fix this is to use an update flag, which is reflected in my changes to this recipe.