### PR TITLE
Fix RefNotFoundException

### DIFF
--- a/src/main/java/org/dstadler/jgit/unfinished/TrackMaster.java
+++ b/src/main/java/org/dstadler/jgit/unfinished/TrackMaster.java
@@ -53,9 +53,9 @@ public class TrackMaster {
 
             // now open the created repository
             FileRepositoryBuilder builder = new FileRepositoryBuilder();
-            try (Repository repository = builder.setGitDir(localPath)
+            try (Repository repository = builder
                     .readEnvironment() // scan environment GIT_* variables
-                    .findGitDir() // scan up the file system tree
+                    .findGitDir(localPath) // scan up the file system tree
                     .build()) {
                 try (Git git = new Git(repository)) {
                     git.branchCreate()


### PR DESCRIPTION
This is the same problem as the one discussed in https://github.com/centic9/jgit-cookbook/pull/90#issuecomment-1375868762

Before this PR, the `TrackMaster` example is failing with:
```
Exception in thread "main" org.eclipse.jgit.api.errors.RefNotFoundException: Ref origin/master cannot be resolved
	at org.eclipse.jgit.api.CreateBranchCommand.getStartPointObjectId(CreateBranchCommand.java:246)
	at org.eclipse.jgit.api.CreateBranchCommand.call(CreateBranchCommand.java:99)
	at org.dstadler.jgit.unfinished.TrackMaster.main(TrackMaster.java:72)
```

After the change:
```
Now tracking master in repository at <absolute-path-to-tmp-folder> from origin/master at https://github.com/github/testrepo.git
```

I don't know why but if you first clone and then open the repo in an other step then `.setGitDir(localPath)` does not work as expected.