### PR TITLE
Fix httpserver sample after Jetty 12 update

### DIFF
--- a/httpserver/src/main/java/org/dstadler/jgit/server/Main.java
+++ b/httpserver/src/main/java/org/dstadler/jgit/server/Main.java
@@ -58,7 +58,7 @@ public class Main {
         context.setContextPath("/");
         server.setHandler(context);
 
-        context.addServlet(gs, "/repo");
+        context.addServlet(gs, "/repo/*");
 
         server.start();
         return server;


### PR DESCRIPTION
Hi @centic9, thanks for all the great examples, they are very helpful!

As you noted here d20bd9bbf8c86dc2c2747e80739d974c4c165111, the httpserver was not working after the update to Jetty 12. Here's a simple fix.